### PR TITLE
reverse media rules for browser print

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -69,7 +69,7 @@
             <img class="is-rounded" src="https://avatars2.githubusercontent.com/u/7221389?s=128&v=4">
           </figure>
         </div>
-        <div class="column has-text-grey-light has-text-right-in-desktop">
+        <div class="column has-text-grey-light has-text-right has-text-centered-mobile">
           <p class="has-text-weight-light">
             123 Your Street
           </p>


### PR DESCRIPTION
`.has-text-right-in-desktop` not working when using browser print (ctrl+p) 
![image](https://user-images.githubusercontent.com/13674295/47272844-5f54f400-d5b5-11e8-9845-5f9a67d9c409.png)