### PR TITLE
Prefetch CSS and make it non-blocking

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -21,7 +21,10 @@
     <link rel="icon" type="image/png" sizes="16x16" href="https://mazipan.github.io/favicon/favicon-16x16.png">
     <meta name="theme-color" content="#bd93f9">
 
-    <link href="https://fonts.googleapis.com/css?family=Raleway" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com/css?family=Raleway">
+    <link rel="dns-prefetch" href="https://fonts.googleapis.com/css?family=Raleway">
+    <link rel="preload" href="https://fonts.googleapis.com/css?family=Raleway" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Raleway"></noscript>
 
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-25065548-2"></script>


### PR DESCRIPTION
This will increase site load score by decreasing blockage of loading. Font will stop blocking loading, will be pre-fetched as soon as page starts to be evaluated (before drawn). Font will be replaced after page is drawn